### PR TITLE
Sign command returns signature as Buffer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,8 +82,6 @@ export default class IronfishApp extends GenericApp {
         const returnCode = errorCodeData[0] * 256 + errorCodeData[1]
         let errorMessage = errorCodeToString(returnCode)
 
-        let signatures: Buffer[] = []
-
         if (
           returnCode === LedgerError.BadKeyHandle ||
           returnCode === LedgerError.DataIsInvalid ||
@@ -92,15 +90,11 @@ export default class IronfishApp extends GenericApp {
           errorMessage = `${errorMessage} : ${response.subarray(0, response.length - 2).toString('ascii')}`
         }
 
-        if (returnCode === LedgerError.NoErrors && response.length > 2) {
-          const signaturesLen = (response.length - 2) / REDJUBJUB_SIGNATURE_LEN
-          for (let i = 0; i < signaturesLen; i++) {
-            const tmpSignature = response.subarray(i * REDJUBJUB_SIGNATURE_LEN, i * REDJUBJUB_SIGNATURE_LEN + REDJUBJUB_SIGNATURE_LEN)
-            signatures.push(tmpSignature)
-          }
+        if (returnCode === LedgerError.NoErrors && response.length == (2 + REDJUBJUB_SIGNATURE_LEN)) {
+          const signature = response.subarray(0, REDJUBJUB_SIGNATURE_LEN)
 
           return {
-            signatures,
+            signature,
             returnCode,
             errorMessage,
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface ResponseProofGenKey extends ResponseBase {
 }
 
 export interface ResponseSign extends ResponseBase {
-  signatures?: Buffer[]
+  signature?: Buffer
 }
 
 export enum IronfishKeys {


### PR DESCRIPTION
Sign command returns only one signature that should be included in all signable descriptions (Spends and Mints)